### PR TITLE
비디오 서비스 AutoMapper 수정하기 - StartVideoSummary Method

### DIFF
--- a/video-service/package-lock.json
+++ b/video-service/package-lock.json
@@ -21,6 +21,7 @@
         "@nestjs/event-emitter": "^1.4.1",
         "@nestjs/platform-express": "^9.0.0",
         "@nestjs/testing": "^9.4.0",
+        "@nestjs/typeorm": "^9.0.1",
         "amazon-s3-uri": "^0.1.1",
         "axios": "^1.3.2",
         "better-sse": "^0.8.0",
@@ -4707,6 +4708,29 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/@nestjs/typeorm": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-9.0.1.tgz",
+      "integrity": "sha512-A2BgLIPsMtmMI0bPKEf4bmzgFPsnvHqNBx3KkvaJ7hJrBQy0OqYOb+Rr06ifblKWDWS2tUPNrAFQbZjtk3PI+g==",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0",
+        "reflect-metadata": "^0.1.13",
+        "rxjs": "^7.2.0",
+        "typeorm": "^0.3.0"
+      }
+    },
+    "node_modules/@nestjs/typeorm/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/@nestjs/websockets": {
       "version": "9.3.2",
@@ -16180,6 +16204,21 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
           "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
+    "@nestjs/typeorm": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-9.0.1.tgz",
+      "integrity": "sha512-A2BgLIPsMtmMI0bPKEf4bmzgFPsnvHqNBx3KkvaJ7hJrBQy0OqYOb+Rr06ifblKWDWS2tUPNrAFQbZjtk3PI+g==",
+      "requires": {
+        "uuid": "8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },

--- a/video-service/package.json
+++ b/video-service/package.json
@@ -74,7 +74,8 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": "./",
+    "modulePaths": ["<rootDir>"],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/video-service/package.json
+++ b/video-service/package.json
@@ -32,6 +32,7 @@
     "@nestjs/event-emitter": "^1.4.1",
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/testing": "^9.4.0",
+    "@nestjs/typeorm": "^9.0.1",
     "amazon-s3-uri": "^0.1.1",
     "axios": "^1.3.2",
     "better-sse": "^0.8.0",
@@ -75,7 +76,9 @@
       "ts"
     ],
     "rootDir": "./",
-    "modulePaths": ["<rootDir>"],
+    "modulePaths": [
+      "<rootDir>"
+    ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/video-service/src/video/application/mapper/summarization.mapper.ts
+++ b/video-service/src/video/application/mapper/summarization.mapper.ts
@@ -1,0 +1,16 @@
+import { Injectable } from "@nestjs/common";
+import { Summarization } from "src/video/domain/summarization/entity/summarization.entity";
+import { StartSummaryDto } from "src/video/interface/dto/summarization/start-summary.dto";
+
+@Injectable()
+export class SummarizationMapper {
+
+    from(startSummaryDto: StartSummaryDto): Summarization {
+        return new Summarization(
+            startSummaryDto.userId,
+            startSummaryDto.originVideoPath,
+            startSummaryDto.category
+        );
+    };
+    
+}

--- a/video-service/src/video/interface/dto/summarization/start-summary.dto.ts
+++ b/video-service/src/video/interface/dto/summarization/start-summary.dto.ts
@@ -1,10 +1,9 @@
-import { AutoMap } from "@automapper/classes";
-
 export class StartSummaryDto {
-    @AutoMap()
     readonly userId: string;
-    @AutoMap()
     readonly originVideoPath: string[];
-    @AutoMap()
     readonly category: string[];
+
+    static of(userId: string, originVideoPath: string[], category: string[]): StartSummaryDto {
+        return { userId, originVideoPath, category };
+    }
 }

--- a/video-service/src/video/interface/mapper/video.profile.ts
+++ b/video-service/src/video/interface/mapper/video.profile.ts
@@ -20,11 +20,6 @@ export class VideoProfile extends AutomapperProfile {
 
     override get profile(): MappingProfile {
         return (mapper) => {
-            /* 요약 시작할 때 요약 되는 비디오의 메타정보로 변환 */ 
-            createMap(mapper, StartSummaryDto, Summarization, 
-                forMember(dest => dest.originVideoPath, mapFrom(source => source.originVideoPath)),
-                forMember(dest => dest.category, mapFrom(source => source.category)),
-            ),
             /* 요약 완료되었을 때 dto를 요약 결과로 변환 */
             createMap(mapper, CompleteSummaryDto, SummarizationResult,
                 forMember(dest => dest.id, mapFrom( source => source.summarizationId)),

--- a/video-service/src/video/interface/video.controller.ts
+++ b/video-service/src/video/interface/video.controller.ts
@@ -45,7 +45,7 @@ export class VideoController {
         영상을 저장하고 AI 팀에게 영상 정보를 전송 완료함 */
     @Post('summary')
     async startVideoSummary(@Body() startSummaryDto: StartSummaryDto): Promise<void> {
-        await this.videoService.startVideoSummary(this.mapper.map(startSummaryDto, StartSummaryDto, Summarization));
+        await this.videoService.startVideoSummary(startSummaryDto);
     }
 
     /* Ai 팀으로부터 오는 요약 정보를 업데이트 */

--- a/video-service/test/integration/database/test-mysql.module.ts
+++ b/video-service/test/integration/database/test-mysql.module.ts
@@ -1,0 +1,15 @@
+import { TypeOrmModuleOptions } from "@nestjs/typeorm";
+import { Summarization } from "src/video/domain/summarization/entity/summarization.entity";
+import { DataSourceOptions } from "typeorm";
+
+export const TestingTypeORMOptions: DataSourceOptions = {
+    type: 'mysql',
+    host: '127.0.0.1',
+    port: 3306,
+    username: 'root',
+    password: '1234',
+    database: 'test',
+    entities: [Summarization],
+    logging: false,
+    synchronize: true
+}

--- a/video-service/test/unit/video/application/mapper/summarization-mapper.spec.ts
+++ b/video-service/test/unit/video/application/mapper/summarization-mapper.spec.ts
@@ -1,0 +1,21 @@
+import { SummarizationMapper } from "src/video/application/mapper/summarization.mapper"
+import { Summarization } from "src/video/domain/summarization/entity/summarization.entity";
+import { StartSummaryDto } from "src/video/interface/dto/summarization/start-summary.dto"
+
+describe('SummarizationMapper Test', () => {
+    let summarizationMapper: SummarizationMapper;
+
+    beforeEach(() => {
+        summarizationMapper = new SummarizationMapper();
+    });
+
+    describe('from()', () => {
+        it('dto를 summarization 객체로 변환해야 한다', () => {
+            const startDto = StartSummaryDto.of('01022223333', ['http:www.aws.com'], ['가족', '희망']);
+            const summarization = summarizationMapper.from(startDto);
+            expect(summarization).toBeInstanceOf(Summarization);
+            expect(summarization.getUserId()).toBe('01022223333');
+            expect(summarization.getOriginVideoPath()[0]).toBe('http:www.aws.com');
+        })
+    })
+})

--- a/video-service/test/unit/video/application/service/video-service.spec.ts
+++ b/video-service/test/unit/video/application/service/video-service.spec.ts
@@ -1,0 +1,54 @@
+import { Test } from "@nestjs/testing"
+import { SummarizationMapper } from "src/video/application/mapper/summarization.mapper";
+import { VideoService } from "src/video/application/video.service"
+import { SummarizationRepository } from "src/video/infra/database/summarization.repository";
+import { TestSummarization } from "../../fixture/test-summarization.fixture";
+import { SummaryStatus } from "src/video/domain/summarization/enum/summary-status.enum";
+import { DataSource } from "typeorm";
+import { TestingTypeORMOptions } from "test/integration/database/test-mysql.module";
+
+describe('VideoService Test', () => {
+    let dataSource: DataSource
+    
+    beforeAll(async () => {
+        const module = await Test.createTestingModule({
+            providers: [
+                VideoService,
+                SummarizationMapper,
+                {
+                    provide: SummarizationRepository,
+                    useValue: {}
+                }
+            ],
+        }).compile();
+        
+        dataSource = new DataSource(TestingTypeORMOptions);
+        await dataSource.initialize();
+    });
+
+    afterAll( async () => {
+        await dataSource.dropDatabase();
+        await dataSource.destroy();
+    });
+
+    describe('startVideoSummary()', () => {
+        it('요약을 시작하면 상태가 SUMMARYING로 변경되어야 한다', () => {
+            // 요약 요청이 들어왔을 때
+            const summarization = TestSummarization.create('01022223333', ['http:www.aws.com'], ['가족', '열정']);
+            summarization.started();
+            expect(summarization.getStatus()).toBe(SummaryStatus.SUMMARYING);
+        });
+
+        it('생성된 요약 요청 정보는 DB에 저장이 되어야 한다', async () => {
+            //요약 요청 정보를 저장하고 났을 때
+            const summarization = TestSummarization.create('01022223333', ['http:www.aws.com'], ['가족', '청년']);
+            summarization.started();
+            const savedSummarization = await dataSource.createEntityManager().save(summarization);
+
+            expect(savedSummarization).toEqual(summarization);
+            expect(savedSummarization.getStatus()).toBe(SummaryStatus.SUMMARYING);
+            expect(savedSummarization.getUserId()).toBe('01022223333');
+        });
+        
+    })
+})

--- a/video-service/test/unit/video/fixture/test-summarization.fixture.ts
+++ b/video-service/test/unit/video/fixture/test-summarization.fixture.ts
@@ -1,0 +1,7 @@
+import { Summarization } from "src/video/domain/summarization/entity/summarization.entity";
+
+export class TestSummarization {
+    static create(userId: string, originVideoPath: string[], category: string[]): Summarization {
+        return new Summarization(userId, originVideoPath, category);
+    };
+}


### PR DESCRIPTION
## 수정 파일
**video-service/src/video/interface/mapper/video.profile.ts**
- StartSummaryDto To Summarization으로 변경하는 Map 삭제

**video-service/src/video/application/mapper/summarization.mapper.ts**
- from(): 요청 정보로부터 요약 객체 생성하는 Method 추가

## 테스트
**video-service/test/integration/database/test-mysql.module.ts**
- 테스트용 Database에 저장하기 위한 옵션

**video-service/test/unit/video/application/mapper/summarization-mapper.spec.ts**
- 만든 Mapper Test

**video-service/test/unit/video/application/service/video-service.spec.ts**
- Return값이 없기에 유닛테스트에서 DB에 저장되는지 확인